### PR TITLE
Add access to Http Response headers

### DIFF
--- a/APEReactiveNetworking/Source/Http.swift
+++ b/APEReactiveNetworking/Source/Http.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public typealias HttpHeaders = [String: String]
+public typealias HttpRequestHeaders = [String: String]
 
 
 public enum HttpMethod: String {

--- a/APEReactiveNetworking/Source/RequestBuilder/ApeRequestBuilder.swift
+++ b/APEReactiveNetworking/Source/RequestBuilder/ApeRequestBuilder.swift
@@ -14,7 +14,7 @@ public class ApeRequestBuilder: HttpRequestBuilder {
     private let endpoint : Endpoint
     private var authHeader: String?
     private var contentTypeHeader = HttpContentType.ApplicationJson
-    private var additionalHeaders: HttpHeaders?
+    private var additionalHeaders: HttpRequestHeaders?
     private var bodyData: NSData?
 
     // MARK: Public
@@ -23,7 +23,7 @@ public class ApeRequestBuilder: HttpRequestBuilder {
         self.endpoint = endpoint
     }
     
-    public func addHeaders(headers: HttpHeaders) -> HttpRequestBuilder {
+    public func addHeaders(headers: HttpRequestHeaders) -> HttpRequestBuilder {
         self.additionalHeaders = headers
         return self
     }
@@ -53,8 +53,8 @@ public class ApeRequestBuilder: HttpRequestBuilder {
 
     // MARK: Private
 
-    private func generateHeaders() -> HttpHeaders {
-        var headers: HttpHeaders = [:]
+    private func generateHeaders() -> HttpRequestHeaders {
+        var headers: HttpRequestHeaders = [:]
 
         if let authorizationHeaderValue = authHeader {
             headers["Authorization"] = authorizationHeaderValue
@@ -72,7 +72,7 @@ public class ApeRequestBuilder: HttpRequestBuilder {
     }
 
 
-    private func generateRequest(headers: HttpHeaders, body: NSData?) -> NSURLRequest {
+    private func generateRequest(headers: HttpRequestHeaders, body: NSData?) -> NSURLRequest {
         guard let url = NSURL(string: endpoint.absoluteUrl) else {
             preconditionFailure("Endpoint contains invalid url")
         }

--- a/APEReactiveNetworking/Source/RequestBuilder/HttpRequestBuilder.swift
+++ b/APEReactiveNetworking/Source/RequestBuilder/HttpRequestBuilder.swift
@@ -16,7 +16,7 @@ public protocol HttpRequestBuilder {
 
     func addAuthHandler(authHandler: AuthenticationHandler) -> HttpRequestBuilder
 
-    func addHeaders(headers: HttpHeaders) -> HttpRequestBuilder
+    func addHeaders(headers: HttpRequestHeaders) -> HttpRequestBuilder
 
     func setBody(rawData rawData: NSData, contentType: HttpContentType) -> HttpRequestBuilder
 

--- a/APEReactiveNetworkingTests/APEReactiveNetworkingTests.swift
+++ b/APEReactiveNetworkingTests/APEReactiveNetworkingTests.swift
@@ -20,7 +20,7 @@ class APEReactiveNetworkingTests: XCTestCase {
         let expectation = expectationWithDescription("Expected status 200 OK within 5 seconds")
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.google.com")!)
-        let producer: SignalProducer<(), NetworkError> = Network().send(request)
+        let producer: SignalProducer<HttpResponseHeaders, NetworkError> = Network().send(request)
             .on(completed: {
                 expectation.fulfill()
             })
@@ -36,7 +36,7 @@ class APEReactiveNetworkingTests: XCTestCase {
         let expectation = expectationWithDescription("Expected timeout")
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.google.com")!)
-        let producer: SignalProducer<(), NetworkError> = Network().send(request, abortAfter: 0.0)
+        let producer: SignalProducer<HttpResponseHeaders, NetworkError> = Network().send(request, abortAfter: 0.0)
             .on(failed: { (error: NetworkError) in
                 XCTAssertEqual(error._code, NetworkError.TimedOut._code)
                 expectation.fulfill()
@@ -74,7 +74,7 @@ class APEReactiveNetworkingTests: XCTestCase {
         var startTime: NSTimeInterval?
         var endTime: NSTimeInterval?
         let request = NSURLRequest(URL: NSURL(string: "http://www._thisisaninvalidURL_asdfasoiddlkdk.com")!)
-        let producer: SignalProducer<(), NetworkError> = Network().send(request, abortAfter:maximumTimePermitted, maxRetries:numberOfRetries)
+        let producer: SignalProducer<HttpResponseHeaders, NetworkError> = Network().send(request, abortAfter:maximumTimePermitted, maxRetries:numberOfRetries)
             .on(
                 started: {
                     //Capture the start time

--- a/Example/Project/DataProvider/ApeChatProvider/ApeChatApi.swift
+++ b/Example/Project/DataProvider/ApeChatProvider/ApeChatApi.swift
@@ -18,11 +18,11 @@ protocol ApeChatApi {
     // MARK: User
 
     func authenticateUser(username: String,
-                          password: String) -> SignalProducer<AuthResponse, NetworkError>
+                          password: String) -> SignalProducer<NetworkResponse<AuthResponse>, NetworkError>
 
-    func getAllUsers() -> SignalProducer<[User], NetworkError>
+    func getAllUsers() -> SignalProducer<NetworkResponse<[User]>, NetworkError>
 
-    func updateUserAvatar (userId: String, avatar: UIImage) -> SignalProducer<User, NetworkError>
+    func updateUserAvatar (userId: String, avatar: UIImage) -> SignalProducer<NetworkResponse<User>, NetworkError>
     
 
     // MARK: Messages

--- a/Example/Project/DataProvider/ApeChatProvider/MockApeChatApiProvider.swift
+++ b/Example/Project/DataProvider/ApeChatProvider/MockApeChatApiProvider.swift
@@ -16,16 +16,16 @@ struct MockApeChatApiProvider { //: ApeChatApi {
     //MARK: ApeChatApi
     
     func authenticateUser(username: String,
-                          password: String) -> SignalProducer<AuthResponse, NetworkError> {
+                          password: String) -> SignalProducer<NetworkResponse<AuthResponse>, NetworkError> {
         return signalProducer()
     }
     
-    func getAllUsers() -> SignalProducer<[User], NetworkError> {
+    func getAllUsers() -> SignalProducer<NetworkResponse<[User]>, NetworkError> {
         return signalProducer()
     }
     
 
-    func updateUserAvatar (userId: String, avatar: UIImage) -> SignalProducer<User, NetworkError> {
+    func updateUserAvatar (userId: String, avatar: UIImage) -> SignalProducer<NetworkResponse<User>, NetworkError> {
         return signalProducer()
     }
 
@@ -36,20 +36,20 @@ struct MockApeChatApiProvider { //: ApeChatApi {
     
     //MARK: Private
     
-    private func signalProducer<T: Unboxable>() -> SignalProducer<[T], NetworkError> {
+    private func signalProducer<T: Unboxable>() -> SignalProducer<NetworkResponse<[T]>, NetworkError> {
         
         return signalProducer()
     }
     
     ///Returns a signal producer that sends a next event containing a parsed model of type 'T' or a 'ParseFailure' if an error occurred.
-    private func signalProducer<T: Unboxable>() -> SignalProducer<T, NetworkError> {
+    private func signalProducer<T: Unboxable>() -> SignalProducer<NetworkResponse<T>, NetworkError> {
         
-        return SignalProducer<T, NetworkError>(){ observer, _disposable in
+        return SignalProducer<NetworkResponse<T>, NetworkError>(){ observer, _disposable in
             guard let model = self.initFromJsonFile(T) else {
                 return observer.sendFailed(.ParseFailure)
             }
             
-            observer.sendNext(model)
+            observer.sendNext(NetworkResponse(responseHeaders: [:], data: model))
             observer.sendCompleted()
         }
     }

--- a/Example/Project/DataProvider/ApeChatProvider/NetworkedApeChatApiProvider.swift
+++ b/Example/Project/DataProvider/ApeChatProvider/NetworkedApeChatApiProvider.swift
@@ -20,7 +20,7 @@ struct NetworkedApeChatApiProvider: ApeChatApi {
     
     //More elaborate example
     func authenticateUser(username: String,
-                          password: String) -> SignalProducer<AuthResponse, NetworkError> {
+                          password: String) -> SignalProducer<NetworkResponse<AuthResponse>, NetworkError> {
         
         //Endpoint for authenticating a user
         let endpoint: Endpoint = ApeChatApiEndpoints.AuthUser
@@ -76,7 +76,7 @@ struct NetworkedApeChatApiProvider: ApeChatApi {
     }
     
     
-    func getAllUsers() -> SignalProducer<[User], NetworkError> {
+    func getAllUsers() -> SignalProducer<NetworkResponse<[User]>, NetworkError> {
         let request = ApeRequestBuilder(endpoint: ApeChatApiEndpoints.GetAllUsers)
             .addAuthHandler(authHandler)
             .build()
@@ -84,7 +84,7 @@ struct NetworkedApeChatApiProvider: ApeChatApi {
     }
     
     
-    func updateUserAvatar(userId: String, avatar: UIImage) -> SignalProducer<User, NetworkError> {
+    func updateUserAvatar(userId: String, avatar: UIImage) -> SignalProducer<NetworkResponse<User>, NetworkError> {
         let avatarRawData = UIImageJPEGRepresentation(avatar, 0.9)!
         
         let request: NSURLRequest = ApeRequestBuilder(endpoint: ApeChatApiEndpoints.UpdateUserAvatar(userId: userId))

--- a/Example/Project/Scenes/Login/Controllers/LoginViewController.swift
+++ b/Example/Project/Scenes/Login/Controllers/LoginViewController.swift
@@ -87,11 +87,10 @@ class LoginViewController: UIViewController {
                     .authenticateUser(self.usernameTextField.text ?? "", password: self.passwordTextField.text ?? "")
                     .start { event in
                         switch event {
-                        case .Next(let authResponse):
+                        case .Next(let networkResponse):
                             //This is a POC - mark the global "authenticated" state that we are authenticated
                             DummyState.authed = true
-                            
-                            self.handleLoginSuccess(authResponse)
+                            self.handleLoginSuccess(networkResponse.data)
                         case .Failed(let error):
                             self.handleLoginError(error)
                         default: break

--- a/Example/Project/Scenes/User/Controllers/UserListViewController.swift
+++ b/Example/Project/Scenes/User/Controllers/UserListViewController.swift
@@ -48,7 +48,7 @@ class UserListViewController: UIViewController {
         }
     }
     
-    private func getAllUsers() -> SignalProducer<[User], NetworkError> {
+    private func getAllUsers() -> SignalProducer<NetworkResponse<[User]>, NetworkError> {
         return apeChatApi.getAllUsers().on(
             started : {
                 print("users started")
@@ -63,7 +63,9 @@ class UserListViewController: UIViewController {
             terminated: {
                 print("users terminated")
             },
-            next: { users in
+            next: { response in
+                print("response headers: \(response.responseHeaders)")
+                let users = response.data
                 print("users received: \(users)")
                 self.dataSource.elements = users
                 self.tableView.reloadData()


### PR DESCRIPTION
- Wrapped data and http response headers in a NetworkResponse struct
- Created two overloaded 'Network::send' functions:
  - One that returns a SignalProducer<HttpResponseHeaders, NetworkError>
  - A second one that receives a parse data block and returns a
    SignalProducer<NetworkResponse, NetworkError>. The NetworkResponse
    contains both the http response headers and the parsed data.
