### PR TITLE
Trim HttpRequestBuilder protocol

### DIFF
--- a/APEReactiveNetworking.xcodeproj/project.pbxproj
+++ b/APEReactiveNetworking.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5F6D488A1D421D630097F426 /* ExponentialSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6D48891D421D630097F426 /* ExponentialSequence.swift */; };
 		5F6D488C1D421D800097F426 /* NetworkActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6D488B1D421D800097F426 /* NetworkActivityIndicator.swift */; };
 		5F6D488E1D421DAB0097F426 /* SignalProducerType+NetworkActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6D488D1D421DAB0097F426 /* SignalProducerType+NetworkActivityIndicator.swift */; };
+		5F7A19131DBF59C2004F1D9F /* APERequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7A19121DBF59C2004F1D9F /* APERequestBuilderTests.swift */; };
 		5FF05A951D40F69F0082575A /* ApeRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF05A8E1D40F69F0082575A /* ApeRequestBuilder.swift */; };
 		5FF05A961D40F69F0082575A /* HttpRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF05A8F1D40F69F0082575A /* HttpRequestBuilder.swift */; };
 		5FF05A9A1D40F6E10082575A /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF05A991D40F6E10082575A /* Endpoint.swift */; };
@@ -42,6 +43,7 @@
 		5F6D48891D421D630097F426 /* ExponentialSequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExponentialSequence.swift; sourceTree = "<group>"; };
 		5F6D488B1D421D800097F426 /* NetworkActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkActivityIndicator.swift; sourceTree = "<group>"; };
 		5F6D488D1D421DAB0097F426 /* SignalProducerType+NetworkActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SignalProducerType+NetworkActivityIndicator.swift"; sourceTree = "<group>"; };
+		5F7A19121DBF59C2004F1D9F /* APERequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APERequestBuilderTests.swift; sourceTree = "<group>"; };
 		5FD47A871D992A1B00EDF45C /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		5FD47A881D992A1B00EDF45C /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
 		5FF05A8E1D40F69F0082575A /* ApeRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApeRequestBuilder.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				6708E91C1D06FFDC00D4191F /* APEReactiveNetworkingTests.swift */,
 				6708E91E1D06FFDC00D4191F /* Info.plist */,
+				5F7A19121DBF59C2004F1D9F /* APERequestBuilderTests.swift */,
 			);
 			path = APEReactiveNetworkingTests;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F7A19131DBF59C2004F1D9F /* APERequestBuilderTests.swift in Sources */,
 				6708E91D1D06FFDC00D4191F /* APEReactiveNetworkingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/APEReactiveNetworking/Source/Http.swift
+++ b/APEReactiveNetworking/Source/Http.swift
@@ -21,8 +21,7 @@ public struct Http {
         case delete
         
         init?(value: String?) {
-            guard
-                let value = value,
+            guard let value = value,
                 let resolved = Method(rawValue: value.lowercased()) else {
                     return nil
             }

--- a/APEReactiveNetworking/Source/RequestBuilder/ApeRequestBuilder.swift
+++ b/APEReactiveNetworking/Source/RequestBuilder/ApeRequestBuilder.swift
@@ -21,13 +21,8 @@ public final class ApeRequestBuilder: HttpRequestBuilder {
         self.endpoint = endpoint
     }
     
-    public func addHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder {
+    public func setHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder {
         additionalHeaders[header.key] = header.value
-        return self
-    }
-    
-    public func setHeaders(_ headers: Http.RequestHeaders) -> HttpRequestBuilder {
-        additionalHeaders = headers
         return self
     }
 

--- a/APEReactiveNetworking/Source/RequestBuilder/HttpRequestBuilder.swift
+++ b/APEReactiveNetworking/Source/RequestBuilder/HttpRequestBuilder.swift
@@ -13,11 +13,8 @@ public protocol HttpRequestBuilder {
     init(endpoint: Endpoint)
     
     /// Adds a header entry to the HttpHeaders. If an entry with the received key already exists it will be overwritten.
-    func addHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder
+    func setHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder
     
-    /// Sets the HttpHeaders. Overwrites all existing headers
-    func setHeaders(_ headers: Http.RequestHeaders) -> HttpRequestBuilder
-
     func setBody(data: Data, contentType: Http.ContentType) -> HttpRequestBuilder
 
     func build() -> ApeURLRequest
@@ -48,19 +45,33 @@ public extension HttpRequestBuilder {
         }
         
         let base64Credentials = credentialsData.base64EncodedString(options: [])
-        return addHeader((key: authorizationHeaderKey, value: "Basic \(base64Credentials)"))
+        return setHeader((key: authorizationHeaderKey, value: "Basic \(base64Credentials)"))
     }
     
     /// Sets the authorization header to "Bearer \(token)"
     public func setAuthorizationHeader(token: String) -> HttpRequestBuilder {
-        return addHeader((key: authorizationHeaderKey, value: "Bearer \(token)"))
+        return setHeader((key: authorizationHeaderKey, value: "Bearer \(token)"))
     }
     
     /// Sets the authorization header to a custom value
     public func setAuthorizationHeader(headerValue: String) -> HttpRequestBuilder {
-        return addHeader((key: authorizationHeaderKey, value: headerValue))
+        return setHeader((key: authorizationHeaderKey, value: headerValue))
     }
     
+    /// Adds a header entry to the HttpHeaders. The header value consists of all the values in the array separated by a comma.
+    public func setHeader(_ header: (key: String, values: [String])) -> HttpRequestBuilder {
+        let valueString = header.values.joined(separator: ",")
+        return setHeader((key: header.key, value: valueString))
+    }
+    
+    /// Sets the received HttpHeaders. If a header key already exists it will be overwritten.
+    public func setHeaders(_ headers: Http.RequestHeaders) -> HttpRequestBuilder {
+        for (_, header) in headers.enumerated() {
+            _ = setHeader(header)
+        }
+        return self
+    }
+
     
     //MARK: - Body
 

--- a/APEReactiveNetworkingTests/APERequestBuilderTests.swift
+++ b/APEReactiveNetworkingTests/APERequestBuilderTests.swift
@@ -1,0 +1,102 @@
+//
+//  APERequestBuilderTests.swift
+//  APEReactiveNetworking
+//
+//  Created by Magnus Eriksson on 2016-10-25.
+//  Copyright © 2016 Apegroup. All rights reserved.
+//
+
+import XCTest
+import ReactiveSwift
+@testable import APEReactiveNetworking
+
+
+class APERequestBuilderTests: XCTestCase {
+    
+    let authHeaderKey = "Authorization"
+    
+    func testImplicitHeaders() {
+        let request = ApeRequestBuilder(endpoint: GoogleEndpoint()).build()
+        guard let headers = request.urlRequest.allHTTPHeaderFields else {
+            return XCTFail("No headers available")
+        }
+        
+        XCTAssertNotNil(headers["X-Client-Device-VendorId"])
+        XCTAssertNotNil(headers["X-Client-Device-Type"])
+        XCTAssertNotNil(headers["X-Client-OS"])
+        XCTAssertNotNil(headers["X-Client-OS-Version"])
+    }
+    
+    func testAuthHeaderCustom() {
+        let token = "CustomToken: This is my custom token"
+        let request = ApeRequestBuilder(endpoint: GoogleEndpoint())
+            .setAuthorizationHeader(headerValue: token)
+            .build()
+        
+        guard let headers = request.urlRequest.allHTTPHeaderFields else {
+            return XCTFail("No headers available")
+        }
+        
+        XCTAssertTrue(headers[authHeaderKey] == token)
+    }
+
+    
+    func testAuthHeaderBasic() {
+        let username = "ape"
+        let password = "group"
+        
+        guard let request = try? ApeRequestBuilder(endpoint: GoogleEndpoint())
+            .setAuthorizationHeader(username: username, password: password)
+            .build() else {
+                return XCTFail("Unable to build request")
+        }
+        guard let headers = request.urlRequest.allHTTPHeaderFields else {
+            return XCTFail("No headers available")
+        }
+        
+        let credentialsString = "\(username):\(password)"
+        guard let credentialsData = credentialsString.data(using: .utf8) else {
+            return XCTFail("Unable to serialize credentials")
+        }
+        
+        let base64Credentials = credentialsData.base64EncodedString(options: [])
+        XCTAssertTrue(headers[authHeaderKey] == "Basic \(base64Credentials)")
+    }
+    
+    
+    func testAuthHeaderBearer() {
+        let token = "This is my bearer token"
+        let request = ApeRequestBuilder(endpoint: GoogleEndpoint())
+            .setAuthorizationHeader(token: token)
+            .build()
+        
+        guard let headers = request.urlRequest.allHTTPHeaderFields else {
+            return XCTFail("No headers available")
+        }
+        
+        XCTAssertTrue(headers[authHeaderKey] == "Bearer \(token)")
+    }
+    
+    func testCustomHeaders() {
+        let key1 = "h1", key2 = "h2", key3 = "h3", key4 = "h4", key5 = "h5"
+        let value1 = "v1", value2 = "v2.1, v2.2, v2.3", value3 = "v3", value4 = "v4", value5 = "v5"
+        let request = ApeRequestBuilder(endpoint: GoogleEndpoint())
+            //Test single header entry
+            .setHeader((key1, value1))
+            //Test single header entry with multiple values
+            .setHeader((key2, value2.components(separatedBy: ",")))
+            //Test several header entries
+            .setHeaders([key3:value3, key4:value4, key5:value5])
+            .build()
+        
+        guard let headers = request.urlRequest.allHTTPHeaderFields else {
+            return XCTFail("No headers available")
+        }
+        
+        XCTAssertTrue(headers[key1] == value1)
+        XCTAssertTrue(headers[key2] == value2)
+        XCTAssertTrue(headers[key3] == value3)
+        XCTAssertTrue(headers[key4] == value4)
+        XCTAssertTrue(headers[key5] == value5)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ Build your request by using a `HttpRequestBuilder`.
 ```swift
 public protocol HttpRequestBuilder {
     init(endpoint: Endpoint)
-    func addHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder
-    func setHeaders(_ headers: Http.RequestHeaders) -> HttpRequestBuilder
+    func setHeader(_ header: (key: String, value: String)) -> HttpRequestBuilder
     func setBody(data: Data, contentType: Http.ContentType) -> HttpRequestBuilder
     func build() -> ApeURLRequest
 }
@@ -178,9 +177,9 @@ let request: ApeURLRequest = requestBuilder.build()
 When using the built-in `ApeRequestBuilder` the following http headers will be included in each request:
 ```swift
 - "X-Client-OS" // The name of the operating system running on the device represented by the receiver, e.g. "iOS"
-- "X-Client-OS-Version" // The current version of the operating system, e.g. "1.2"
+- "X-Client-OS-Version" // The current version of the operating system, e.g. "10.0"
 - "X-Client-Device-Type" // The device model name, e.g. "iPhone 6s Plus"
-- "X-Client-Device-VendorId"  // An alphanumeric string that is the same for apps that come from the same vendor running on the same device, or "unknown" if unavailable
+- "X-Client-Device-VendorId"  // An alphanumeric string that is the same for apps that come from the same vendor running on the same device, or "unknown" if unavailable, e.g. "9C32B72F-8532-4F73-BA76-18C9E522E539"
 ```
 
 ### Authentication
@@ -220,7 +219,7 @@ let requestBuilder = ApeRequestBuilder(endpoint: endpoint).setHeaders(customHead
 
 Or by adding a single header entry (if the header already exists it will be replaced by the new value):
 ```swift
-let requestBuilder = ApeRequestBuilder(endpoint: endpoint).addHeader(("CustomKey","CustomValue"))
+let requestBuilder = ApeRequestBuilder(endpoint: endpoint).setHeader(("CustomKey","CustomValue"))
 ```
 
 ### Setting the request body


### PR DESCRIPTION
Simplify HttpRequestBuilder conformance by moving protocol requirement 'setHeaders'
into an extension (it can be implemented using the 'setHeader' method).